### PR TITLE
add support for backend proxy Host header

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ docker run -p 8080:80 f5devcentral/f5-demo-httpd:nginx
 docker run --rm -e F5DEMO_APP=website f5devcentral/f5-demo-httpd:nginx
 # simple frontend
 docker run --rm -e F5DEMO_APP=frontend -e F5DEMO_BACKEND_URL=http://10.1.20.10/backend.shtml f5devcentral/f5-demo-httpd:nginx
+# simple frontend with backend url using proxy host header
+docker run --rm -e F5DEMO_APP=frontend -e F5DEMO_BACKEND_URL=http://10.10.10.10/backend.shtml -e F5DEMO_BACKEND_HOST=backend.corp f5devcentral/f5-demo-httpd:nginx
 # simple backend
 docker run --rm -e F5DEMO_APP=backend f5devcentral/f5-demo-httpd:nginx
 # different name/color for non-ssl/ssl
@@ -67,6 +69,7 @@ Other variables for "website"
 /index.shtml: simple site
 /frontend.shtml: simple frontend (for reverse-proxy demo)
 /backend.shtml: simple backend
+/backend/: proxy request to backend server
 /website.shtml: Simple website
 /headers/: Output of Client/Server HTTP headers
 /headers.json: Output of client headers in JSON

--- a/conf.d/f5demo.template
+++ b/conf.d/f5demo.template
@@ -100,8 +100,10 @@ server {
    location /backend/ {
      resolver ${NAMESERVER} valid=30s;
      set $backend ${F5DEMO_BACKEND_URL};
+     set $backend_host "${F5DEMO_BACKEND_HOST}";
      proxy_pass $backend;
      proxy_http_version 1.1;
+     proxy_set_header Host $backend_host;
      proxy_set_header Connection "";
      proxy_set_header User-Agent "Frontend App/1.0";
      proxy_set_header X-Forwarded-For "$remote_addr";

--- a/nginx-entrypoint.sh
+++ b/nginx-entrypoint.sh
@@ -60,7 +60,7 @@ then
     fi
     export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
     # build nginx config from template
-    envsubst '$F5DEMO_NODENAME $F5DEMO_NODENAME_SSL $F5DEMO_COLOR $F5DEMO_COLOR_SSL $F5DEMO_BACKEND_URL $F5DEMO_APP $NAMESERVER' < /etc/nginx/conf.d/f5demo.template > /etc/nginx/conf.d/f5demo.conf
+    envsubst '$F5DEMO_NODENAME $F5DEMO_NODENAME_SSL $F5DEMO_COLOR $F5DEMO_COLOR_SSL $F5DEMO_BACKEND_URL $F5DEMO_BACKEND_HOST $F5DEMO_APP $NAMESERVER' < /etc/nginx/conf.d/f5demo.template > /etc/nginx/conf.d/f5demo.conf
   fi
 
 


### PR DESCRIPTION
To build a simple F5XC demo app with frontend and backend pointing to custom VIP without DNS, setting F5DEMO_BACKEND_URL won't get resolved via /etc/hosts, requiring `proxy_set_header Host ...`.

With this change, it is possible to run the frontend container with

```
/bin/podman run --name frontend -p 80:80 -e F5DEMO_APP=frontend -e F5DEMO_BACKEND_URL=http://10.10.10.10/backend.shtml -e F5DEMO_BACKEND_HOST=backend.corp marcelwiget/f5-demo-httpd:nginx
```

and the backend container with

```
bin/podman run --name backend -p 8080:80 -e F5DEMO_APP=backend marcelwiget/f5-demo-httpd:nginx
```

Example

```
$ curl -H Host:frontend.corp http://10.10.10.10/backend/

<!DOCTYPE html><html><head><title>Demo App</title><link rel="stylesheet" href="/stylesheets/style.css"></head>
<body><img src="/images/f5-logo.png" align="left" height="75" width="75">
  <h1>Backend App</h1><p>Welcome to Demo App</p>
  <p>This is a very basic demo of a Backend Application that should only be accessible from a Frontend Application.</p>
  <p>Note that on this page that the Client IP and User-Agent will differ from the Frontend Application.</p>
  <ul>
  <li><a href="/">Frontend App</a></li>
  </ul>

<p><b>Server IP</b> = 10.88.0.3</p>

<p><b>Client IP</b> = 10.100.0.77</p>

<p><b>Request Headers</b> =</p>
<div class="indent"><p>host: backend.corp</p>
<p>user-agent: Frontend App/1.0</p>
<p>
x-forwarded-for: 10.100.4.118,10.100.6.167</p>
<pre>
<!#--#printenv -->
               </pre>
</body></html>
```

