### PR TITLE
httpd-foreground script requires bash

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -6,6 +6,7 @@ COPY server.key /usr/local/apache2/conf/server.key
 COPY httpd-foreground /usr/local/bin/httpd-foreground
 COPY htdocs /usr/local/apache2/htdocs
 RUN chown -R 1001:0 /usr/local/apache2/logs/ && chmod 770 /usr/local/apache2/logs/
+RUN apk add bash
 EXPOSE 8080
 EXPOSE 8443
 USER 1001


### PR DESCRIPTION
httpd-foreground uses bash to support shell array for COLORS[], but  httpd:2.4-alpine doesn't have bash (anymore?). 

I built and pushed working container to docker hub:  marcelwiget/f5-demo-httpd:openshift